### PR TITLE
Don't close active inflate/deflate objects

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -117,10 +117,18 @@ Session.prototype.processOutgoingMessage = function(message, callback) {
 };
 
 Session.prototype.close = function() {
-  if (this._inflate && this._inflate.close) this._inflate.close();
+  // If we have a persistent inflate, close it. However, if the persistent
+  // inflate is currently being used (eg, we're waiting for the callback from
+  // inflate.flush), don't close it; processIncomingMessage will close it when
+  // it sees that this._inflate is not set.
+  if (this._inflate && this._inflate.close && !this._lockIn) {
+    this._inflate.close();
+  }
   this._inflate = null;
 
-  if (this._deflate && this._deflate.close) this._deflate.close();
+  if (this._deflate && this._deflate.close && !this._lockOut) {
+    this._deflate.close();
+  }
   this._deflate = null;
 };
 


### PR DESCRIPTION
Previously, inflate/deflate objects that were shared between multiple
messages (due to context takeover) would be immediately closed on
Session.close even if some data was currently being fed through
zlib. With this change, Session.close only closes idle inflate/deflate
objects; it still drops them from this._inflate/_deflate so that
process*Message will close them later.

Fixes #1.

**TWO CAVEATS**

(1) This has no tests. I'm going to try to write some now.  It does make some Meteor tests pass though!

(2) This raises an API question to me: it appears that permessage-deflate can still call process*Message callbacks after session.close is called.  Is this the intended extension API? Does this lead to any issues at the websocket-driver level?
